### PR TITLE
match type error in ruby 2.3.0

### DIFF
--- a/lib/ruby_dig.rb
+++ b/lib/ruby_dig.rb
@@ -1,11 +1,10 @@
 module RubyDig
   def dig(key, *rest)
-    if value = (self[key] rescue nil)
-      if rest.empty?
-        value
-      elsif value.respond_to?(:dig)
-        value.dig(*rest)
-      end
+    value = self[key]
+    if rest.empty? || value.nil?
+      value
+    elsif value.respond_to?(:dig)
+      value.dig(*rest)
     end
   end
 end

--- a/test/ruby_dig_test.rb
+++ b/test/ruby_dig_test.rb
@@ -30,8 +30,10 @@ class RubyDigTest
         assert_equal nil, ['zero', 'one', 'two'].dig(4)
       end
 
-      it "returns nil when dig index not an integer" do
-        assert_equal nil, ['zero', 'one', 'two'].dig(:four)
+      it "raises when dig index not an integer" do
+        assert_raises(TypeError) do
+          ['zero', 'one', 'two'].dig(:four)
+        end
       end
 
       it "digs into any object that implements dig" do


### PR DESCRIPTION
@ColinDKelley I think we are still unsure if this behavior will make it to the final release, but this will match the current behavior better.

Up to you if you want to wait until the discussion subsides before merging.