### PR TITLE
Raise appropriate exceptions and return false values

### DIFF
--- a/lib/ruby_dig.rb
+++ b/lib/ruby_dig.rb
@@ -1,6 +1,6 @@
 module RubyDig
   def dig(key, *rest)
-    if value = (self[key] rescue nil)
+    if value = self[key]
       if rest.empty?
         value
       elsif value.respond_to?(:dig)

--- a/lib/ruby_dig.rb
+++ b/lib/ruby_dig.rb
@@ -1,11 +1,10 @@
 module RubyDig
   def dig(key, *rest)
-    if value = self[key]
-      if rest.empty?
-        value
-      elsif value.respond_to?(:dig)
-        value.dig(*rest)
-      end
+    value = self[key]
+    if value.nil? || rest.empty?
+      value
+    elsif value.respond_to?(:dig)
+      value.dig(*rest)
     end
   end
 end

--- a/lib/ruby_dig.rb
+++ b/lib/ruby_dig.rb
@@ -5,6 +5,8 @@ module RubyDig
       value
     elsif value.respond_to?(:dig)
       value.dig(*rest)
+    else
+      fail TypeError, "#{value.class} does not have #dig method"
     end
   end
 end

--- a/test/ruby_dig_test.rb
+++ b/test/ruby_dig_test.rb
@@ -30,8 +30,8 @@ class RubyDigTest
         assert_equal nil, ['zero', 'one', 'two'].dig(4)
       end
 
-      it "returns nil when dig index not an integer" do
-        assert_equal nil, ['zero', 'one', 'two'].dig(:four)
+      it "raises TypeError when dig index not an integer" do
+        assert_raises(TypeError) { ['zero', 'one', 'two'].dig(:four) }
       end
 
       it "digs into any object that implements dig" do

--- a/test/ruby_dig_test.rb
+++ b/test/ruby_dig_test.rb
@@ -37,6 +37,10 @@ class RubyDigTest
       it "digs into any object that implements dig" do
         assert_equal [:a, :b], [0, Diggable.new].dig(1, :a, :b)
       end
+
+      it "returns the value false" do
+        assert_equal false, [:a, [true, false]].dig(1, 1)
+      end
     end
 
     describe "Hash" do
@@ -58,6 +62,10 @@ class RubyDigTest
 
       it "digs into any object that implements dig" do
         assert_equal [:a, :b], {diggable: Diggable.new}.dig(:diggable, :a, :b)
+      end
+
+      it "returns the value false" do
+        assert_equal false, {first: "Homer", last: "Simpson", sobber: false}.dig(:sobber)
       end
     end
 

--- a/test/ruby_dig_test.rb
+++ b/test/ruby_dig_test.rb
@@ -22,8 +22,8 @@ class RubyDigTest
         assert_equal 'twelve', ['zero', ['ten', 'eleven', 'twelve'], 'two'].dig(1, 2)
       end
 
-      it "returns nil when nested array doesn't support dig" do
-        assert_equal nil, ['zero', 'one', 'two'].dig(1, 2)
+      it "raises TypeError when nested array doesn't support dig" do
+        assert_raises(TypeError) { ['zero', 'one', 'two'].dig(1, 2) }
       end
 
       it "returns nil when dig not found" do
@@ -52,8 +52,8 @@ class RubyDigTest
         assert_equal 'Homer', {mom: {first: "Marge", last: "Bouvier"}, dad: {first: "Homer", last: "Simpson"}}.dig(:dad, :first)
       end
 
-      it "returns nil when nested hash doesn't support dig" do
-        assert_equal nil, {mom: {first: "Marge", last: "Bouvier"}, dad: "Homer Simpson"}.dig(:dad, :first)
+      it "raises TypeError when nested hash doesn't support dig" do
+        assert_raises(TypeError) { {mom: {first: "Marge", last: "Bouvier"}, dad: "Homer Simpson"}.dig(:dad, :first) }
       end
 
       it "returns nil when dig not found" do


### PR DESCRIPTION
Now that Ruby 2.3 is final, we should try to match the behavior of this library to the one of actual Ruby.

This pull request fixes the behavior in three places, two of which raise additional errors as done in Ruby 2.3, one fixes a logic bug.

* If a value doesn't support dig, Ruby 2.3 raises a `TypeError`
* If the requested key of an array isn't an `Integer`, the dig in Ruby 2.3 raises a `TypeError`, similar to the normal subscript operator.
* If the value is falsey but not `nil`, i.e. `false`, the value should be returned instead of just converted to `nil`