### PR TITLE
Add dig to Structs

### DIFF
--- a/lib/ruby_dig.rb
+++ b/lib/ruby_dig.rb
@@ -1,6 +1,11 @@
 module RubyDig
   def dig(key, *rest)
-    value = self[key]
+    value = begin
+      self[key]
+    rescue NameError, IndexError
+      Struct === self ? nil : raise
+    end
+
     if value.nil? || rest.empty?
       value
     elsif value.respond_to?(:dig)
@@ -17,6 +22,10 @@ if RUBY_VERSION < '2.3'
   end
 
   class Hash
+    include RubyDig
+  end
+
+  class Struct
     include RubyDig
   end
 end

--- a/test/ruby_dig_test.rb
+++ b/test/ruby_dig_test.rb
@@ -69,6 +69,39 @@ class RubyDigTest
       end
     end
 
+    describe "Struct" do
+      Person = Struct.new(:first, :last, :misc)
+
+      it "digs a struct by key" do
+        assert_equal 'Homer', Person.new("Homer", "Simpson").dig(:first)
+      end
+
+      it "digs a struct by index" do
+        assert_equal 'Homer', Person.new("Homer", "Simpson").dig(0)
+      end
+
+      it "digs a nested struct by keys" do
+        assert_equal 'Bart', Person.new("Marge", "Bouvier", ["Lisa", "Bart", "Maggie"]).dig(:misc, 1)
+      end
+
+      it "raises TypeError when nested hash doesn't support dig" do
+        assert_raises(TypeError) { Person.new("Marge", "Bouvier", "Lisa").dig(:misc, 1) }
+      end
+
+      it "returns nil when dig not found" do
+        assert_equal nil, Person.new("Homer", "Simpson").dig(:invalid)
+        assert_equal nil, Person.new("Homer", "Simpson").dig(3)
+      end
+
+      it "digs into any object that implements dig" do
+        assert_equal [:a, :b], Person.new("Homer", "Simpson", Diggable.new).dig(:misc, :a, :b)
+      end
+
+      it "returns the value false" do
+        assert_equal false, Person.new("Homer", "Simpson", false).dig(:misc)
+      end
+    end
+
     describe "Nested Hash and Array" do
       it "navigates both" do
         assert_equal 'Lisa', {mom: {first: "Marge", last: "Bouvier"},


### PR DESCRIPTION
This implements #8 by adding dig to Structs.

Here, we have to introduce some additional checks since `Struct#[]` raises exceptions when we try to access a key or index that does not exist. To quote the [documentation](https://ruby-doc.org/core-2.2.0/Struct.html#method-i-5B-5D):

> Returns the value of the given struct `member` or the member at the given `index`. Raises `NameError` if the member does not exist and `IndexError` if the index is out of range.

For Structs, we assume nil for these cases. If we receive such an error from any other class (although unlikely), we re-raise it. This allows others to include our module into their own classes and still get roughly compatible behavior without unduly swallowing exceptions.